### PR TITLE
Solve leetcode 771

### DIFF
--- a/src/leetcode771.rs
+++ b/src/leetcode771.rs
@@ -1,0 +1,16 @@
+fn solution(jewels: String, stones: String) -> i32 {
+    stones.chars().filter(|&s| jewels.contains(s)).count() as i32
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leetcode771_case1() {
+        let jewels: String = String::from("aA");
+        let stones: String = String::from("aAAbbbb");
+        let desired: i32 = 3;
+
+        assert_eq!(solution(jewels, stones), desired);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,5 +9,5 @@ mod leetcode1672;
 mod leetcode1929;
 mod leetcode2160;
 mod leetcode2235;
-
+mod leetcode771;
 fn main() {}


### PR DESCRIPTION
**Problem Overview**
This solution returns the count of characters in stones(string) that also appear in jewels(string).

**Solution Details**
- The function iterates over stones and filters characters that are present in jewels.
- The filter method is used to count characters in stones that match any in jewels.
- The solution is efficient given the constraints and adheres to the case-sensitive requirement.

**Test Cases**
A test case is included for input jewels = "aA" and stones = "aAAbbbb", verifying the output 3. Additional tests may be added to cover edge cases such as empty stones or jewels.