### PR TITLE
Solve LeetCode 1290

### DIFF
--- a/src/leetcode1290.rs
+++ b/src/leetcode1290.rs
@@ -1,0 +1,49 @@
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct ListNode {
+    pub val: i32,
+    pub next: Option<Box<ListNode>>,
+}
+
+impl ListNode {
+    #[inline]
+    fn new(val: i32) -> Self {
+        ListNode { next: None, val }
+    }
+}
+
+pub fn get_decimal_value(head: Option<Box<ListNode>>) -> i32 {
+    let mut now = head;
+    let mut result = 0;
+
+    while let Some(node) = now {
+        result = (result << 1) | node.val;
+        now = node.next;
+    }
+    result
+}
+
+//create a linked list fot testing
+fn create_linked_list(nums: Vec<i32>) -> Option<Box<ListNode>> {
+    let mut head = None;
+    let mut now = &mut head;
+
+    for &val in nums.iter() {
+        let new_node = Box::new(ListNode::new(val));
+        *now = Some(new_node);
+        now = &mut now.as_mut().expect("this node has a next link").next;
+    }
+
+    head
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leetcode1290_case1() {
+        let head = create_linked_list(vec![1, 0, 1]);
+        let desired = 5;
+
+        assert_eq!(get_decimal_value(head), desired);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod leetcode1108;
 mod leetcode1281;
+mod leetcode1290;
 mod leetcode1313;
 mod leetcode1365;
 mod leetcode1431;


### PR DESCRIPTION
**Problem Overview**
This Pull Request addresses LeetCode problem 1290, which requires converting a binary number represented as a linked list into its decimal integer form. Each node in the singly-linked list contains a binary digit (0 or 1), ordered with the most significant bit at the head. The goal is to decode this binary representation and return the corresponding decimal number.

**Solution Details**
- The solution traverses the linked list, starting from the head.
- For each node, the current result is shifted left by one bit (equivalent to multiplying by 2), and the node's value is combined using bitwise-OR to accumulate the binary-to-decimal conversion.
- The solution runs in O(n) time, where n is the number of nodes in the list, since it requires a single traversal of the list.

**Helper Function and Testing**
- A helper function create_linked_list is included to build a linked list from a vector of integers, simplifying testing.
- A test case is provided to validate that a linked list with nodes [1, 0, 1] correctly converts to the decimal number 5.