### PR TITLE
Solve LeetCode 1688

### DIFF
--- a/src/leetcode1688.rs
+++ b/src/leetcode1688.rs
@@ -1,0 +1,28 @@
+fn solution(mut n: i32) -> i32 {
+    let mut cnt = 0;
+    while n > 1 {
+        n = match n % 2 {
+            0 => {
+                cnt += n / 2;
+                n / 2
+            }
+            _ => {
+                cnt += (n - 1) / 2;
+                (n - 1) / 2 + 1
+            }
+        };
+    }
+    cnt
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leetcode1688_case1() {
+        let n: i32 = 14;
+        let desired: i32 = 13;
+
+        assert_eq!(solution(n), desired);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod leetcode1480;
 mod leetcode1512;
 mod leetcode1528;
 mod leetcode1672;
+mod leetcode1688;
 mod leetcode1720;
 mod leetcode1773;
 mod leetcode1859;


### PR DESCRIPTION
**Problem Overview**
This Pull Request provides a solution for LeetCode problem 1688, which calculates the number of matches needed to reduce n teams to a single champion in a tournament where each match eliminates one team. The function counts matches based on the number of teams in each round.

**Solution Details**
- A while loop continues until only one team remains (n > 1).
- For each iteration, the function calculates matches played based on whether n is even or odd, adding to a counter (cnt) and updating the number of advancing teams.
- The result, cnt, represents the total number of matches required.