### PR TITLE
Use Result for error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,4 @@ name = "leetcode"
 version = "0.1.0"
 edition = "2021"
 
-[workspace.metadata.clippy]
-must_use = true
-
 [dependencies]

--- a/src/solutions/leetcode1290.rs
+++ b/src/solutions/leetcode1290.rs
@@ -11,7 +11,7 @@ impl ListNode {
     }
 }
 
-#[must_use]
+#[must_use = "The return value indicates the decimal value of the binary number."]
 pub fn get_decimal_value(head: Option<Box<ListNode>>) -> i32 {
     std::iter::successors(head, |node| node.next.clone())
         .map(|node| node.val)

--- a/src/solutions/leetcode1773.rs
+++ b/src/solutions/leetcode1773.rs
@@ -1,22 +1,45 @@
-#[must_use]
-pub fn solution(items: &[Vec<String>], rule_key: &str, rule_value: &str) -> usize {
-    let rule_index = match rule_key {
-        "type" => 0,
-        "color" => 1,
-        "name" => 2,
-        _ => return 0,
+/// Finds the number of items that match the given rule key and value.
+///
+/// # Arguments
+///
+/// * `items` - A slice of vectors, where each vector represents an item with its type, color, and name.
+/// * `rule_key` - The key to filter items by ("type", "color", or "name").
+/// * `rule_value` - The value to match against the specified rule key.
+///
+/// # Returns
+///
+/// A `Result<usize, String>` where:
+/// - `Ok(usize)` contains the count of matching items.
+/// - `Err(String)` contains an error message if the rule key is invalid.
+///
+/// # Errors
+///
+/// Returns an error if the `rule_key` is not "type", "color", or "name".
+///
+#[must_use = "The return value indicates success or failure. Please handle it explicitly."]
+pub fn solution(items: &[Vec<String>], rule_key: &str, rule_value: &str) -> Result<usize, String> {
+    let rule_index = if rule_key == "type" {
+        Some(0)
+    } else if rule_key == "color" {
+        Some(1)
+    } else if rule_key == "name" {
+        Some(2)
+    } else {
+        None
     };
 
-    items
-        .iter()
-        .filter(|item| {
-            if let Some(value) = item.get(rule_index) {
-                value == rule_value
-            } else {
-                false
-            }
+    rule_index
+        .ok_or_else(|| format!("Invalid rule_key: {rule_key}"))
+        .map(|index| {
+            items.iter().fold(0, |acc, item| {
+                if let Some(value) = item.get(index) {
+                    if value == rule_value {
+                        return acc + 1;
+                    }
+                }
+                acc
+            })
         })
-        .count()
 }
 
 #[cfg(test)]
@@ -44,7 +67,34 @@ mod tests {
         ];
         let rule_key = String::from("color");
         let rule_value = String::from("silver");
-        let desired = 1;
+        let desired = Ok(1);
+
+        assert_eq!(solution(&items, &rule_key, &rule_value), desired);
+    }
+
+    #[test]
+    fn invalid_rule_key_case() {
+        let items: Vec<Vec<String>> = vec![
+            vec![
+                String::from("phone"),
+                String::from("blue"),
+                String::from("pixel"),
+            ],
+            vec![
+                String::from("computer"),
+                String::from("silver"),
+                String::from("lenovo"),
+            ],
+            vec![
+                String::from("phone"),
+                String::from("gold"),
+                String::from("iphone"),
+            ],
+        ];
+        let rule_key = String::from("color");
+        let rule_value = String::from("silver");
+        let desired = Ok(1);
+
         assert_eq!(solution(&items, &rule_key, &rule_value), desired);
     }
 }

--- a/src/solutions/leetcode1773.rs
+++ b/src/solutions/leetcode1773.rs
@@ -71,30 +71,4 @@ mod tests {
 
         assert_eq!(solution(&items, &rule_key, &rule_value), desired);
     }
-
-    #[test]
-    fn invalid_rule_key_case() {
-        let items: Vec<Vec<String>> = vec![
-            vec![
-                String::from("phone"),
-                String::from("blue"),
-                String::from("pixel"),
-            ],
-            vec![
-                String::from("computer"),
-                String::from("silver"),
-                String::from("lenovo"),
-            ],
-            vec![
-                String::from("phone"),
-                String::from("gold"),
-                String::from("iphone"),
-            ],
-        ];
-        let rule_key = String::from("color");
-        let rule_value = String::from("silver");
-        let desired = Ok(1);
-
-        assert_eq!(solution(&items, &rule_key, &rule_value), desired);
-    }
 }


### PR DESCRIPTION
- Replaced match-based error handling with `Result`
- Added a message to the `#[must_use]` to ensure return value usage.
- Updated documentation to include `# Errors` section for better
  clarity.

It closes #58.